### PR TITLE
add Remotes for p5 and suggests for Rbitcoin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,10 +24,13 @@ Imports:
     assertthat,
     htmlwidgets,
     glue
+Remotes:
+    seankross/p5
 Suggests:
     testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    Rbitcoin
 Depends:
     R(>= 3.3.2)
 License: GPL-3
@@ -36,7 +39,7 @@ URL: https://github.com/ropensci/realtime
 BugReports: https://github.com/ropensci/realtime/issues
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1
-Collate: 
+Collate:
     'color.R'
     'global.R'
     'internal.R'


### PR DESCRIPTION
This adds a Remotes field in the DESCRIPTION which allows the user to install the package, installing Sean Kross's `p5` package. I also added a Suggests for `Rbitcoin`, as this is used in the vignette.

Looking forward to using this, great job! :)